### PR TITLE
Remove unused comment in StatusCommand.java

### DIFF
--- a/src/main/java/de/construkter/glitzoriumSMP/tablist/StatusCommand.java
+++ b/src/main/java/de/construkter/glitzoriumSMP/tablist/StatusCommand.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 public class StatusCommand implements CommandExecutor, TabCompleter {
 
-    // Liste der verfügbaren Status-Prefixe
     private static final List<String> STATUS_OPTIONS = Arrays.asList(
             "ghg", "bambus", "redstone", "live", "afk", "pvp", "builder", "troll", "polizei", "list"
     );


### PR DESCRIPTION
Eliminate the redundant comment describing the list of available status prefixes, which is self-explanatory through the variable name STATUS_OPTIONS. This cleanup simplifies the code and removes unnecessary clutter.